### PR TITLE
Suggestionbox

### DIFF
--- a/content/suggest.md
+++ b/content/suggest.md
@@ -1,4 +1,4 @@
 +++
 template = "redirect.html"
-extra.url = "https://docs.google.com/forms/d/e/1FAIpQLSeIs2O5GT0gHVvtwER54PkiXaaz2yLTBh-dKZXLkqHGrOd-yQ/viewform?usp=pp_url"
+extra.url = "https://docs.google.com/forms/d/1OpVRk5aqHY2YWUasPRYCB_YmoEyKyFDOQpLL-5Z-daA/viewform"
 +++

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -27,7 +27,7 @@
                 <ul>
                     <li><a href="https://www.acm.org/">ACM National</a></li>
                     <li><a href="https://www.cs.umn.edu/">CS&amp;E Department</a></li>
-                    <li><a href="https://z.umn.edu/suggest_acm">Suggestion Box</a></li>
+                    <li><a href="https://z.umn.edu/acm2026suggest">Suggestion Box</a></li>
                     <li><a href="/tos">Terms of Service</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
there was some dead/deleted form link in the suggestion box in the footer, and suggest.md had an unpublished version

used the preexisting suggest form in 2025-2026 google folder and shortened it 

same link in both cases, and it now is connected to a google sheet in the folder, if anything looks wrong please let me know!

ideally able to change z.umn.edu/suggest_acm, but in the meantime thistle work